### PR TITLE
delete url_key in formurl admin panel

### DIFF
--- a/src/bot/admin.py
+++ b/src/bot/admin.py
@@ -96,10 +96,9 @@ class FormUrlAdmin(admin.ModelAdmin):
     list_display = (
         "title",
         "url",
-        "url_key",
     )
-    list_filter = ("title", "url_key")
-    search_fields = ("title", "url_key")
+    list_filter = ("title",)
+    search_fields = ("title",)
 
     def has_delete_permission(self, request, obj=None):
         """Запрещает удалять ссылки."""


### PR DESCRIPTION
# Description

удалил url_key из админ панели FormUrl

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Мой код соответствует code-style данного проекта

