### PR TITLE
fix docker images update

### DIFF
--- a/.github/workflows/stage_deploy.yml
+++ b/.github/workflows/stage_deploy.yml
@@ -104,7 +104,7 @@ jobs:
 
             cd infra/stage/
             docker compose -f docker_compose_stage.yaml down
-            docker container prune --force
+            docker system prune -a --force
             docker compose -f docker_compose_stage.yaml up --build -d
 
             docker exec random-coffee-bot python manage.py migrate


### PR DESCRIPTION
# Description

Зашел на удаленный сервер, остановил контейнеры, посмотрел images - созданы были более 10 дней назад.
Команда `docker compose -f docker_compose_stage.yaml down`  останавливает и удаляет контейнеры, следовательно вместо `docker container prune --force` выбрал `docker system prune -a --force` чтобы удалить и образы, которые не хотели обновляться.

## Type of change

Пожалуйста, удалите варианты, которые не относятся к ПР-у.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Зашел на удаленный сервер, остановил контейнеры, удалил и контейнеры и образы - `docker system prune -a --force`.
Пересобрал и запустил `docker compose -f docker_compose_stage.yaml up --build -d`.
Проверил бота, вроде работает.

## Checklist:

- [x] Мой код соответствует code-style данного проекта
- [x] Я провел самоанализ собственного кода
